### PR TITLE
recipes-bsp/u-boot: Change compile task content to deploy task

### DIFF
--- a/recipes-bsp/u-boot/u-boot-tinker-board.bb
+++ b/recipes-bsp/u-boot/u-boot-tinker-board.bb
@@ -23,8 +23,11 @@ inherit pythonnative
 IDBLOADER = "idbloader.img"
 
 do_compile_append () {
-    # Burn bootloader
+    cp ${B}/spl/${SPL_BINARY} ${B}/${SPL_BINARY}
+}
+
+do_deploy_append () {
+    # Create bootloader image
     ${B}/tools/mkimage -n ${SOC_FAMILY} -T rksd -d ${B}/spl/${SPL_BINARY} ${DEPLOYDIR}/${IDBLOADER}
     cat ${B}/u-boot.bin >>${DEPLOYDIR}/${IDBLOADER}
-    cp ${B}/spl/${SPL_BINARY} ${B}/${SPL_BINARY}
 }


### PR DESCRIPTION
The creation of idbloader.img was done at compile time.
This made the idbloader.img unavailable at install time.
After the above changes u-boot-spl-dtb.bin had to be moved
in the intall_prepend task and insidie the u-boot deploy dir.

Signed-off-by: Vicentiu Galanopulo <vicentiu@resin.io>