### PR TITLE
machine/rk3288: Change serial console to ttyS3

### DIFF
--- a/conf/machine/include/rk3288.inc
+++ b/conf/machine/include/rk3288.inc
@@ -11,7 +11,7 @@ MACHINEOVERRIDES =. "mali-gpu:mali-midgard:"
 PREFERRED_PROVIDER_virtual/kernel = "linux-tinker-board"
 PREFERRED_VERSION_linux-tinker-board = "4.4.103"
 
-SERIAL_CONSOLES = "115200;ttyS2"
+SERIAL_CONSOLES = "115200;ttyS3"
 KERNEL_IMAGETYPE = "zImage"
 KBUILD_DEFCONFIG = "miniarm-rk3288_defconfig"
 


### PR DESCRIPTION
Reason for this change is that u-boot outputs
serial info on ttyS3 and with this change the
kernel will be aligned to that.

Signed-off-by: Vicentiu Galanopulo <vicentiu@resin.io>